### PR TITLE
Added new flag cellular_use_apn_lookup which is true by default. This…

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -129,15 +129,15 @@ nsapi_error_t do_connect()
         if (retcode == NSAPI_ERROR_AUTH_FAILURE) {
             print_function("\n\nAuthentication Failure. Exiting application\n");
             return retcode;
+        } else if (retcode != NSAPI_ERROR_OK && retry_counter > RETRY_COUNT) {
+            snprintf(print_text, PRINT_TEXT_LENGTH, "\n\nFatal connection failure: %d\n", retcode);
+            print_function(print_text);
+            return retcode;
         } else if (retcode != NSAPI_ERROR_OK) {
             snprintf(print_text, PRINT_TEXT_LENGTH, "\n\nCouldn't connect: %d, will retry\n", retcode);
             print_function(print_text);
             retry_counter++;
             continue;
-        } else if (retcode != NSAPI_ERROR_OK && retry_counter > RETRY_COUNT) {
-            snprintf(print_text, PRINT_TEXT_LENGTH, "\n\nFatal connection failure: %d\n", retcode);
-            print_function(print_text);
-            return retcode;
         }
 
         break;

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -9,6 +9,10 @@
             "help": "Options are TRACE_LEVEL_ERROR,TRACE_LEVEL_WARN,TRACE_LEVEL_INFO,TRACE_LEVEL_DEBUG",
             "macro_name": "MBED_TRACE_MAX_LEVEL",
             "value": "TRACE_LEVEL_INFO"
+        },
+        "cellular_use_apn_lookup": {
+            "help": "If set to true then APN lookup is done if credentials are not set by application.",
+            "value": true
         }
 	},
     "target_overrides": {


### PR DESCRIPTION
… means that apn database is searched for apn, username and password if not provided by application. Fixed bug when connection fails.